### PR TITLE
fixed #1024 - Moved Record to Device ID

### DIFF
--- a/ntc_templates/templates/cisco_nxos_show_cdp_neighbors_detail.textfsm
+++ b/ntc_templates/templates/cisco_nxos_show_cdp_neighbors_detail.textfsm
@@ -9,6 +9,7 @@ Value INTERFACE_IP (.*)
 Value CAPABILITIES (.*[^\s])
 
 Start
+  ^Device ID -> Continue.Record
   ^Device ID:${DEST_HOST}
   ^System Name: ${SYSNAME}
   ^Interface address\(es\):\s*(^[1-9]\d*|$$) -> GetInterfaceIP
@@ -16,7 +17,6 @@ Start
   ^Platform: ${PLATFORM}, Capabilities: ${CAPABILITIES}\s*$$
   ^Interface: ${LOCAL_PORT}, Port ID \(outgoing port\): ${REMOTE_PORT}
   ^Version: -> GetVersion
-  ^----- -> Record
 
 GetIP
   ^.*IP.+Address: ${MGMT_IP} -> Start


### PR DESCRIPTION
Moved Record to Device ID from separators dashes

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_nxos_show_cdp_neighbors_detail.textfsm

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixing issue #1024 - Cisco 7710 issue with not having a separating dashes between neighbors. Moved the record to the Device ID (continue.record). DEST_HOST is required so it doesn't stop working on versions with the ---- separators.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Broken
[['redacted.test.com', '', '10.0.0.4', 'C9300-48UXM', 'TenGigabitEthernet1/1/8', 'Ethernet7/15', 'Cisco IOS Software [Everest], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 16.6.6, RELEASE SOFTWARE 
(fc1)', '10.0.0.3', 'Switch IGMP Filtering']]

Fixed
[['redacted.test.com', '', '10.0.0.1', 'C9300-48UXM', 'TenGigabitEthernet1/1/7', 'Ethernet7/14', 'Cisco IOS Software [Everest], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 16.6.6, RELEASE SOFTWARE 
(fc1)', '10.0.0.1', 'Switch IGMP Filtering'], ['redacted.test.com', '', '10.0.0.4', 'C9300-48UXM', 'TenGigabitEthernet1/1/8', 'Ethernet7/15', 'Cisco IOS Software [Everest], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 16.6.6, RELEASE SOFTWARE (fc1)', '10.0.0.3', 'Switch IGMP Filtering']]
```
